### PR TITLE
Fix label "When to Schedule", spelling of "drop-down"

### DIFF
--- a/docs/Unit 2 Exercise 10.md
+++ b/docs/Unit 2 Exercise 10.md
@@ -35,7 +35,7 @@ In the **Annual Plan Plus One Freq** job, create a new frequency that will utili
 8. Click the **Add** button.
 9. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```15th+30th-B```.
-  * In the **When to Scheduled** dop-down menu, select **On Intervals**.
+  * In the **When to Schedule** drop-down menu, select **On Intervals**.
   * In the **On Intervals** section, check the boxes for **15** and **30**.
   * In the **A/O/B/N** section, select **Before Date**.
   * Make sure the **Day Type** is set to **Working**.
@@ -58,7 +58,7 @@ The **Forecast** screen should show the **15th and 30th days of each month** as 
 18. Click the **Add** button.
 19. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```Annual```.
-  * In the **When to Scheduled** dop-down menu, select **Annual Plan**.
+  * In the **When to Schedule** drop-down menu, select **Annual Plan**.
   * In the **Calendar** drop-down menu, select **Master Holiday**.
   * In the **A/O/B/N** section, select **On Date**.
   * Click the **Save** button.
@@ -80,7 +80,7 @@ The **Forecast** screen should show the **dates selected on the Master Holiday i
 28. Click the **Add** button.
 29. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```Annual+1WD```.
-  * In the **When to Scheduled** dop-down menu, select **Annual Plan**.
+  * In the **When to Schedule** drop-down menu, select **Annual Plan**.
   * In the **Calendar** drop-down menu, select **My First Calendar**.
   * in the **Offset Days**, enter ```1```.
   * In the **A/O/B/N** section, select **On Date**.

--- a/docs/Unit 2 Exercise 12.md
+++ b/docs/Unit 2 Exercise 12.md
@@ -33,7 +33,7 @@ Create a new Schedule called **Multiple and Negative Frequencies** that runs Mon
 14. Click the **Add** button.
 15. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```15th-B```.
-  * In the **When to Scheduled** dop-down menu, select **On Day**.
+  * In the **When to Schedule** drop-down menu, select **On Day**.
   * In the **On** *X* **days of week**, enter ```15```.
   * In the **Day Type** field, select **On 15th day**.
   * In the **A/O/B/N** section, select **Before Date**.
@@ -62,7 +62,7 @@ Create a new Schedule called **Multiple and Negative Frequencies** that runs Mon
 34. Click the **Lock** button to enter **Admin Mode**.
 35. In the Frequency Manager Wizard:
   * In the **Name** field, enter ```Mon-Fri-N```.
-  * In the **When to Scheduled** dop-down menu, select **All Weeks**.
+  * In the **When to Schedule** drop-down menu, select **All Weeks**.
   * In the **Days of the Week**, select **Monday-Friday**.
   * In the **A/O/B/N** section, select **Not Schedule**.
   * Click the **Save** button.

--- a/docs/Unit 2 Exercise 8.md
+++ b/docs/Unit 2 Exercise 8.md
@@ -37,7 +37,7 @@ In the **On Day Freq** job, create a new frequency named that will run on the 1s
 8. Click the **Add** button.
 9. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```Tue+Thurs-B```.
-  * In the **When to Scheduled** dop-down menu, select **All Weeks**.
+  * In the **When to Schedule** drop-down menu, select **All Weeks**.
   * In the **Days of the Week** section, select **Tuesday** and **Thursday**.
   * In the **A/O/B/N** section, select **Before Date**.
   * Make sure the **Day Type** is set to **Working**.
@@ -61,7 +61,7 @@ The **Forecast** screen should show **all Tuesday and Thursday** dates in green 
 18. Click the **Add** button.
 19. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```4th-Thurs-B```.
-  * In the **When to Scheduled** dop-down menu, select **On Occurrence**.
+  * In the **When to Schedule** drop-down menu, select **On Occurrence**.
   * In the **On Occurrence** drop-down menu, select **Fourth**.
   * In the **Period** drop-down, select **Month**.
   * In the **Days of the Week** section, select **Thursday**.
@@ -87,7 +87,7 @@ The **Forecast** screen should show the **4th Thursday of every month** should b
 28. Click the **Add** button.
 29. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```1st-WDOM```.
-  * In the **When to Scheduled** dop-down menu, select **On Day**.
+  * In the **When to Schedule** drop-down menu, select **On Day**.
   * In the **On** *X* **days of week**, enter ```1```.
   * In the **Day Type** field, select **On 1st working day**.
   * In the **A/O/B/N** section, select **On Date**.

--- a/docs/Unit 2 Exercise 9.md
+++ b/docs/Unit 2 Exercise 9.md
@@ -38,7 +38,7 @@ In the **End of Period Freq** job, create a new frequency named that will run on
 8. Click the **Add** button.
 9. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```OnRequest```.
-  * In the **When to Scheduled** dop-down menu, select **On Request**.
+  * In the **When to Schedule** drop-down menu, select **On Request**.
   * In the **Request Date** field, select a date on the calendar that is in the past.
   * Click the **Save** button.
 10. In the **Active** column, select the frequency then select **Forecast**.
@@ -59,7 +59,7 @@ The **Forecast** screen should show only the date that you chose in green.
 18. Click the **Add** button.
 19. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```BOM-A```.
-  * In the **When to Scheduled** dop-down menu, select **Beg of Period**.
+  * In the **When to Schedule** drop-down menu, select **Beg of Period**.
   * In the **Period** drop-down, select **Month**.
   * In the **A/O/B/N** section, select **After Date**.
   * Make sure the **Day Type** is set to **Working**.
@@ -82,7 +82,7 @@ The **Forecast** screen should show the **first working day of every month** as 
 28. Click the **Add** button.
 29. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```Mid-Wed-A```.
-  * In the **When to Scheduled** dop-down menu, select **Mid of Period**.
+  * In the **When to Schedule** drop-down menu, select **Mid of Period**.
   * In the **Period** drop-down, select **Month**.
   * In the **Days of the Week** field, select **Wednesday**.
   * In the **A/O/B/N** section, select **After Date**.
@@ -106,7 +106,7 @@ The **Forecast** screen should show the **Wednesday closest to the middle of eve
 38. Click the **Add** button.
 39. In the **Frequency Manager Wizard**:
   * In the **Name** field, enter ```EOM-B```.
-  * In the **When to Scheduled** dop-down menu, select **End of Period**.
+  * In the **When to Schedule** drop-down menu, select **End of Period**.
   * In the **Period** drop-down, select **Month**.
   * In the **A/O/B/N** section, select **Before Date**.
   * Make sure the **Day Type** is set to **Working**.


### PR DESCRIPTION
The OpCon Frequency Manager Wizard has a "When To Schedule" dropdown.

This pull request corrects the spelling of the "When to Schedule" label and the spelling of "drop-down" in several places.
